### PR TITLE
Update build module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -167,7 +167,7 @@ data "aws_caller_identity" "default" {}
 data "aws_region" "default" {}
 
 module "build" {
-  source                = "git::https://github.com/cloudposse/terraform-aws-codebuild.git?ref=tags/0.11.0"
+  source                = "git::https://github.com/cloudposse/terraform-aws-codebuild.git?ref=tags/0.12.1"
   enabled               = "${var.enabled}"
   namespace             = "${var.namespace}"
   name                  = "${var.name}"


### PR DESCRIPTION
## What:
- update build module from 0.11.0 to 0.12.1

## Why:
- adds ability to run task during build process, which might be used to run one-off task for database migrations