### PR TITLE
Codepipeline depends_on each policy attachment to avoid races

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -209,6 +209,13 @@ resource "aws_codepipeline" "source_build_deploy" {
     type     = "S3"
   }
 
+  depends_on = [
+    "aws_iam_role_policy_attachment.default",
+    "aws_iam_role_policy_attachment.s3",
+    "aws_iam_role_policy_attachment.codebuild",
+    "aws_iam_role_policy_attachment.codebuild_s3",
+  ]
+
   stage {
     name = "Source"
 


### PR DESCRIPTION
This adds a `depends_on` clause to the `aws_codepipeline` resource pointing to each `aws_iam_role_policy_attachment`. This avoids a race condition where the policy attachments are not yet available when the CodePipeline kicks off causing the CodeBuild stage to fail.