### PR TITLE
Update terraform GitHub repository webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,17 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 ## Usage
 
 
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-ecs-codepipeline/releases).
+
+
+
 ### Trigger on GitHub Push
 
 In this example, we'll trigger the pipeline anytime the `master` branch is updated.
 ```hcl
 module "ecs_push_pipeline" {
-  source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.1.2"
+  source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
   name               = "app"
   namespace          = "eg"
   stage              = "staging"
@@ -68,7 +73,7 @@ In this example, we'll trigger anytime a new GitHub release is cut by setting th
 
 ```hcl
 module "ecs_release_pipeline" {
-  source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.1.2"
+  source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
   name               = "app"
   namespace          = "eg"
   stage              = "staging"
@@ -180,7 +185,7 @@ Available targets:
 |------|-------------|
 | badge_url | The URL of the build badge when badge_enabled is enabled |
 | webhook_id | The CodePipeline webhook's ARN. |
-| webhook_url | The CodePipeline webhook's URL. POST events to this endpoint to trigger the target. |
+| webhook_url | The CodePipeline webhook's URL. POST events to this endpoint to trigger the target |
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -63,7 +63,7 @@ usage: |-
   In this example, we'll trigger the pipeline anytime the `master` branch is updated.
   ```hcl
   module "ecs_push_pipeline" {
-    source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.1.2"
+    source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
     name               = "app"
     namespace          = "eg"
     stage              = "staging"
@@ -83,7 +83,7 @@ usage: |-
 
   ```hcl
   module "ecs_release_pipeline" {
-    source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.1.2"
+    source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
     name               = "app"
     namespace          = "eg"
     stage              = "staging"
@@ -106,7 +106,7 @@ usage: |-
 # Example usage
 examples: |-
   Complete usage can be seen in the [terraform-aws-ecs-web-app](https://github.com/cloudposse/terraform-aws-ecs-web-app/blob/master/main.tf) module.
-  
+
   ## Example Buildspec
 
   Here's an example `buildspec.yaml`. Stick this in the root of your project repository.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -40,5 +40,5 @@
 |------|-------------|
 | badge_url | The URL of the build badge when badge_enabled is enabled |
 | webhook_id | The CodePipeline webhook's ARN. |
-| webhook_url | The CodePipeline webhook's URL. POST events to this endpoint to trigger the target. |
+| webhook_url | The CodePipeline webhook's URL. POST events to this endpoint to trigger the target |
 

--- a/main.tf
+++ b/main.tf
@@ -306,7 +306,7 @@ resource "aws_codepipeline_webhook" "webhook" {
 }
 
 module "github_webhooks" {
-  source               = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=tags/0.1.1"
+  source               = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=tags/0.3.0"
   enabled              = "${local.enabled && var.webhook_enabled == "true" ? "true" : "false"}"
   github_organization  = "${var.repo_owner}"
   github_repositories  = ["${var.repo_name}"]
@@ -314,6 +314,5 @@ module "github_webhooks" {
   webhook_url          = "${local.webhook_url}"
   webhook_secret       = "${local.webhook_secret}"
   webhook_content_type = "json"
-  name                 = "web"
   events               = ["${var.github_webhook_events}"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ output "webhook_id" {
 }
 
 output "webhook_url" {
-  description = "The CodePipeline webhook's URL. POST events to this endpoint to trigger the target."
+  description = "The CodePipeline webhook's URL. POST events to this endpoint to trigger the target"
   value       = "${local.webhook_url}"
   sensitive   = true
 }


### PR DESCRIPTION
## what
* Bump `terraform-github-repository-webhooks` version
* Remove unsupported `name` variable
* Rebuild README

## why
* `github_repository_webhook` does not have `name` attribute
* https://github.com/cloudposse/terraform-github-repository-webhooks/pull/8

