### PR TITLE
Add `github_webhooks_token` and `s3_bucket_force_destroy` variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,19 +73,19 @@ In this example, we'll trigger anytime a new GitHub release is cut by setting th
 
 ```hcl
 module "ecs_release_pipeline" {
-  source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
-  name               = "app"
-  namespace          = "eg"
-  stage              = "staging"
-  github_oauth_token = "xxxxxxxxxxxxxx"
-  repo_owner         = "cloudposse"
-  repo_name          = "example"
-  branch             = "master"
-  service_name       = "example"
-  ecs_cluster_name   = "example-ecs-cluster"
-  privileged_mode    = "true"
-  github_webhook_events = ["release"]
-  webhook_filter_json_path = "$.action"
+  source                      = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
+  name                        = "app"
+  namespace                   = "eg"
+  stage                       = "staging"
+  github_oauth_token          = "xxxxxxxxxxxxxx"
+  repo_owner                  = "cloudposse"
+  repo_name                   = "example"
+  branch                      = "master"
+  service_name                = "example"
+  ecs_cluster_name            = "example-ecs-cluster"
+  privileged_mode             = "true"
+  github_webhook_events       = ["release"]
+  webhook_filter_json_path    = "$.action"
   webhook_filter_match_equals = "published"
 }
 ```
@@ -160,8 +160,9 @@ Available targets:
 | ecs_cluster_name | ECS Cluster Name | string | - | yes |
 | enabled | Enable `CodePipeline` creation | string | `true` | no |
 | environment_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build. | list | `<list>` | no |
-| github_oauth_token | GitHub Oauth Token with permissions to access private repositories | string | - | yes |
-| github_webhook_events | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/). | list | `<list>` | no |
+| github_oauth_token | GitHub OAuth Token with permissions to access private repositories | string | - | yes |
+| github_webhook_events | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/) | list | `<list>` | no |
+| github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
 | image_repo_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `UNSET` | no |
 | image_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `latest` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `app` | no |
@@ -170,6 +171,7 @@ Available targets:
 | privileged_mode | If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images | string | `false` | no |
 | repo_name | GitHub repository name of the application to be built and deployed to ECS. | string | - | yes |
 | repo_owner | GitHub Organization or Username. | string | - | yes |
+| s3_bucket_force_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | string | `false` | no |
 | service_name | ECS Service Name | string | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `default` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit', 'XYZ')` | map | `<map>` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -83,19 +83,19 @@ usage: |-
 
   ```hcl
   module "ecs_release_pipeline" {
-    source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
-    name               = "app"
-    namespace          = "eg"
-    stage              = "staging"
-    github_oauth_token = "xxxxxxxxxxxxxx"
-    repo_owner         = "cloudposse"
-    repo_name          = "example"
-    branch             = "master"
-    service_name       = "example"
-    ecs_cluster_name   = "example-ecs-cluster"
-    privileged_mode    = "true"
-    github_webhook_events = ["release"]
-    webhook_filter_json_path = "$.action"
+    source                      = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
+    name                        = "app"
+    namespace                   = "eg"
+    stage                       = "staging"
+    github_oauth_token          = "xxxxxxxxxxxxxx"
+    repo_owner                  = "cloudposse"
+    repo_name                   = "example"
+    branch                      = "master"
+    service_name                = "example"
+    ecs_cluster_name            = "example-ecs-cluster"
+    privileged_mode             = "true"
+    github_webhook_events       = ["release"]
+    webhook_filter_json_path    = "$.action"
     webhook_filter_match_equals = "published"
   }
   ```

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -15,8 +15,9 @@
 | ecs_cluster_name | ECS Cluster Name | string | - | yes |
 | enabled | Enable `CodePipeline` creation | string | `true` | no |
 | environment_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build. | list | `<list>` | no |
-| github_oauth_token | GitHub Oauth Token with permissions to access private repositories | string | - | yes |
-| github_webhook_events | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/). | list | `<list>` | no |
+| github_oauth_token | GitHub OAuth Token with permissions to access private repositories | string | - | yes |
+| github_webhook_events | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/) | list | `<list>` | no |
+| github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
 | image_repo_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `UNSET` | no |
 | image_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `latest` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `app` | no |
@@ -25,6 +26,7 @@
 | privileged_mode | If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images | string | `false` | no |
 | repo_name | GitHub repository name of the application to be built and deployed to ECS. | string | - | yes |
 | repo_owner | GitHub Organization or Username. | string | - | yes |
+| s3_bucket_force_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | string | `false` | no |
 | service_name | ECS Service Name | string | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `default` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit', 'XYZ')` | map | `<map>` | no |

--- a/main.tf
+++ b/main.tf
@@ -13,10 +13,11 @@ module "codepipeline_label" {
 }
 
 resource "aws_s3_bucket" "default" {
-  count  = "${local.enabled ? 1 : 0}"
-  bucket = "${module.codepipeline_label.id}"
-  acl    = "private"
-  tags   = "${module.codepipeline_label.tags}"
+  count         = "${local.enabled ? 1 : 0}"
+  bucket        = "${module.codepipeline_label.id}"
+  acl           = "private"
+  force_destroy = "${var.s3_bucket_force_destroy}"
+  tags          = "${module.codepipeline_label.tags}"
 }
 
 module "codepipeline_assume_label" {
@@ -171,7 +172,7 @@ data "aws_caller_identity" "default" {}
 data "aws_region" "default" {}
 
 module "build" {
-  source                = "git::https://github.com/cloudposse/terraform-aws-codebuild.git?ref=tags/0.12.1"
+  source                = "git::https://github.com/cloudposse/terraform-aws-codebuild.git?ref=tags/0.16.0"
   enabled               = "${var.enabled}"
   namespace             = "${var.namespace}"
   name                  = "${var.name}"
@@ -306,11 +307,11 @@ resource "aws_codepipeline_webhook" "webhook" {
 }
 
 module "github_webhooks" {
-  source               = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=tags/0.3.0"
+  source               = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=tags/0.4.0"
   enabled              = "${local.enabled && var.webhook_enabled == "true" ? "true" : "false"}"
   github_organization  = "${var.repo_owner}"
   github_repositories  = ["${var.repo_name}"]
-  github_token         = "${var.github_oauth_token}"
+  github_token         = "${var.github_webhooks_token}"
   webhook_url          = "${local.webhook_url}"
   webhook_secret       = "${local.webhook_secret}"
   webhook_content_type = "json"

--- a/variables.tf
+++ b/variables.tf
@@ -29,11 +29,19 @@ variable "service_name" {
 }
 
 variable "github_oauth_token" {
-  description = "GitHub Oauth Token with permissions to access private repositories"
+  type        = "string"
+  description = "GitHub OAuth Token with permissions to access private repositories"
+}
+
+variable "github_webhooks_token" {
+  type        = "string"
+  default     = ""
+  description = "GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable"
 }
 
 variable "github_webhook_events" {
-  description = "A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/)."
+  description = "A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/)"
+  type        = "list"
   default     = ["push"]
 }
 
@@ -165,4 +173,9 @@ variable "webhook_filter_json_path" {
 variable "webhook_filter_match_equals" {
   description = "The value to match on (e.g. refs/heads/{Branch})"
   default     = "refs/heads/{Branch}"
+}
+
+variable "s3_bucket_force_destroy" {
+  description = "A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error"
+  default     = false
 }


### PR DESCRIPTION
## what
* Add `github_webhooks_token` variable
* Add `s3_bucket_force_destroy` variable

## why
* Make GitHub token for creating webhooks optional. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable. Sourcing from the `GITHUB_TOKEN` environment variable is useful when the module is provisioned from geodesic or CI/CD that have access to the `GITHUB_TOKEN` environment variable, which in turn could be sourced from SSM using chamber

* `s3_bucket_force_destroy` is a boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error

## references
* https://github.com/cloudposse/terraform-github-repository-webhooks/releases/tag/0.4.0
