### PR TITLE
feat: update terraform-github-repository-webhooks dependency

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -309,7 +309,7 @@ resource "aws_codepipeline_webhook" "webhook" {
 }
 
 module "github_webhooks" {
-  source               = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=tags/0.5.0"
+  source               = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=tags/0.6.0"
   enabled              = var.enabled && var.webhook_enabled ? true : false
   github_organization  = var.repo_owner
   github_repositories  = [var.repo_name]


### PR DESCRIPTION
Update the dependency in order to get anonymous access, provided via https://github.com/cloudposse/terraform-github-repository-webhooks/pull/15.