### PR TITLE
feat: expose anonymous github setting for webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Available targets:
 | github_oauth_token | GitHub OAuth Token with permissions to access private repositories | string | - | yes |
 | github_webhook_events | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/) | list(string) | `<list>` | no |
 | github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
+| github_webhooks_anonymous | Github Anonymous API (if `true`, token must not be set as GITHUB_TOKEN or `github_webhooks_token`) | bool | `false` | no |
 | image_repo_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | - | yes |
 | image_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `latest` | no |
 | name | Name of the application | string | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,6 +17,7 @@
 | github_oauth_token | GitHub OAuth Token with permissions to access private repositories | string | - | yes |
 | github_webhook_events | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/) | list(string) | `<list>` | no |
 | github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
+| github_webhooks_anonymous | Github Anonymous API (if `true`, token must not be set as GITHUB_TOKEN or `github_webhooks_token`) | bool | `false` | no |
 | image_repo_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | - | yes |
 | image_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | string | `latest` | no |
 | name | Name of the application | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -314,6 +314,7 @@ module "github_webhooks" {
   github_organization  = var.repo_owner
   github_repositories  = [var.repo_name]
   github_token         = var.github_webhooks_token
+  github_anonymous     = var.github_webhooks_anonymous
   webhook_url          = local.webhook_url
   webhook_secret       = local.webhook_secret
   webhook_content_type = "json"

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,12 @@ variable "github_webhooks_token" {
   description = "GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable"
 }
 
+variable "github_webhooks_anonymous" {
+  type        = bool
+  default     = false
+  description = "Github Anonymous API (if `true`, token must not be set as GITHUB_TOKEN or `github_webhooks_token`)"
+}
+
 variable "github_webhook_events" {
   type        = list(string)
   description = "A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/)"


### PR DESCRIPTION
## what
* Expose github_webhooks anonymous setting on webhooks module as variable

## why
* This was addressed in #32, which was merged. That PR, however, relied on the token being empty to use the anonymous setting. That logic was fixed in [this PR](https://github.com/cloudposse/terraform-github-repository-webhooks/pull/18), since a prior PR in the webhooks module intended for use by this feature introduced a bug.

## references
* #32 
* https://github.com/cloudposse/terraform-github-repository-webhooks/pull/18