### PR TITLE
Allow CodePipeline to deploy to multiple services at once. 

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -51,7 +51,8 @@
 | repo\_name | GitHub repository name of the application to be built and deployed to ECS | `string` | n/a | yes |
 | repo\_owner | GitHub Organization or Username | `string` | n/a | yes |
 | s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
-| service\_name | ECS Service Name | `string` | n/a | yes |
+| service\_name | ECS Service Names | `string` | `""` | no |
+| service\_names | ECS Service Names | `list(string)` | `[]` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
 | tags | Additional tags (\_e.g.\_ { BusinessUnit : ABC }) | `map(string)` | `{}` | no |
 | webhook\_authentication | The type of authentication to use. One of IP, GITHUB\_HMAC, or UNAUTHENTICATED | `string` | `"GITHUB_HMAC"` | no |

--- a/main.tf
+++ b/main.tf
@@ -432,7 +432,7 @@ resource "random_string" "webhook_secret" {
 }
 
 locals {
-  service_names = compact(concat(var.service_names, [var.service_name]))
+  service_names  = compact(concat(var.service_names, [var.service_name]))
   webhook_secret = join("", random_string.webhook_secret.*.result)
   webhook_url    = join("", aws_codepipeline_webhook.webhook.*.url)
 }

--- a/main.tf
+++ b/main.tf
@@ -407,7 +407,7 @@ resource "aws_codepipeline" "bitbucket" {
       for_each = local.service_names
 
       content {
-        name            = "Deploy ${action.value}"
+        name            = format("Deploy-%s", action.value)
         category        = "Deploy"
         owner           = "AWS"
         provider        = "ECS"

--- a/main.tf
+++ b/main.tf
@@ -316,20 +316,25 @@ resource "aws_codepipeline" "default" {
   stage {
     name = "Deploy"
 
-    action {
-      name            = "Deploy"
-      category        = "Deploy"
-      owner           = "AWS"
-      provider        = "ECS"
-      input_artifacts = ["task"]
-      version         = "1"
+    dynamic "action" {
+      for_each = local.service_names
 
-      configuration = {
-        ClusterName = var.ecs_cluster_name
-        ServiceName = var.service_name
+      content {
+        name            = "Deploy-${action.value}"
+        category        = "Deploy"
+        owner           = "AWS"
+        provider        = "ECS"
+        input_artifacts = ["task"]
+        version         = "1"
+
+        configuration = {
+          ServiceName = action.value
+          ClusterName = var.ecs_cluster_name
+        }
       }
     }
   }
+
 }
 
 # https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html#action-reference-CodestarConnectionSource-example
@@ -393,17 +398,21 @@ resource "aws_codepipeline" "bitbucket" {
   stage {
     name = "Deploy"
 
-    action {
-      name            = "Deploy"
-      category        = "Deploy"
-      owner           = "AWS"
-      provider        = "ECS"
-      input_artifacts = ["task"]
-      version         = "1"
+    dynamic "action" {
+      for_each = local.service_names
 
-      configuration = {
-        ClusterName = var.ecs_cluster_name
-        ServiceName = var.service_name
+      content {
+        name            = "Deploy ${action.value}"
+        category        = "Deploy"
+        owner           = "AWS"
+        provider        = "ECS"
+        input_artifacts = ["task"]
+        version         = "1"
+
+        configuration = {
+          ServiceName = action.value
+          ClusterName = var.ecs_cluster_name
+        }
       }
     }
   }
@@ -418,6 +427,7 @@ resource "random_string" "webhook_secret" {
 }
 
 locals {
+  service_names = compact(concat(var.service_names, [var.service_name]))
   webhook_secret = join("", random_string.webhook_secret.*.result)
   webhook_url    = join("", aws_codepipeline_webhook.webhook.*.url)
 }

--- a/main.tf
+++ b/main.tf
@@ -320,7 +320,7 @@ resource "aws_codepipeline" "default" {
       for_each = local.service_names
 
       content {
-        name            = "Deploy-${action.value}"
+        name            = format("Deploy-%s", action.value)
         category        = "Deploy"
         owner           = "AWS"
         provider        = "ECS"

--- a/variables.tf
+++ b/variables.tf
@@ -53,12 +53,12 @@ variable "ecs_cluster_name" {
 variable "service_name" {
   type        = string
   description = "ECS Service Names"
-  default = ""
+  default     = ""
 }
 variable "service_names" {
   type        = list(string)
   description = "ECS Service Names"
-  default = []
+  default     = []
 }
 
 variable "github_anonymous" {

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,13 @@ variable "ecs_cluster_name" {
 
 variable "service_name" {
   type        = string
-  description = "ECS Service Name"
+  description = "ECS Service Names"
+  default = ""
+}
+variable "service_names" {
+  type        = list(string)
+  description = "ECS Service Names"
+  default = []
 }
 
 variable "github_anonymous" {


### PR DESCRIPTION
## what
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
> This will allow to deploy a build to multiple destinations. 


## why
* Provide the justifications for the changes (e.g. business case). 
> Previously there was a 1-1 mapping between code build & code deploy. Prior to this change, in order to deploy the same image to multiple destinations, one would have to duplicate the CodePipeline module for each deploy destination. 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
> I simply allowed to pass multiple service_names as deploy targets. 

<img width="1303" alt="Screen Shot 2020-09-08 at 18 56 43" src="https://user-images.githubusercontent.com/167488/92545510-28b61000-f205-11ea-8feb-a9df79555558.png">



