### PR TITLE
prevent github OAuthToken from causing unwanted changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -249,6 +250,7 @@ Available targets:
 | webhook\_id | The CodePipeline webhook's ID |
 | webhook\_url | The CodePipeline webhook's URL. POST events to this endpoint to trigger the target |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -76,3 +77,4 @@
 | webhook\_id | The CodePipeline webhook's ID |
 | webhook\_url | The CodePipeline webhook's URL. POST events to this endpoint to trigger the target |
 
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -330,6 +330,11 @@ resource "aws_codepipeline" "default" {
       }
     }
   }
+
+  lifecycle {
+    # prevent github OAuthToken from causing updates, since it's removed from state file
+    ignore_changes = [stage[0].action[0].configuration]
+  }
 }
 
 # https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html#action-reference-CodestarConnectionSource-example


### PR DESCRIPTION
## what
* Adding a lifecycle block to ignore changes in source stage

## why
* When using github OAuthToken, the `aws_codepipeline` resource doesn't save the token in the state file. This causes it to detect changes on every apply, regardless of a change in the terraform files.

## references
* https://github.com/terraform-providers/terraform-provider-aws/issues/2854
