### PR TITLE
Support TF 0.12 with pinned GitHub provider 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,6 @@ Available targets:
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | environment\_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build | <pre>list(object(<br>    {<br>      name  = string<br>      value = string<br>  }))</pre> | `[]` | no |
-| github\_anonymous | Github Anonymous API (if `true`, token must not be set as GITHUB\_TOKEN or `github_token`) | `bool` | `false` | no |
 | github\_oauth\_token | GitHub OAuth Token with permissions to access private repositories | `string` | `""` | no |
 | github\_webhook\_events | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/) | `list(string)` | <pre>[<br>  "push"<br>]</pre> | no |
 | github\_webhooks\_token | GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.0 |
 | local | >= 1.2 |
 | null | >= 2.0 |
@@ -237,7 +237,7 @@ Available targets:
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `""` | no |
 | cache\_type | The type of storage that will be used for the AWS CodeBuild project cache. Valid values: NO\_CACHE, LOCAL, and S3.  Defaults to S3.  If cache\_type is S3, it will create an S3 bucket for storing codebuild cache inside | `string` | `"S3"` | no |
 | codestar\_connection\_arn | CodeStar connection ARN required for Bitbucket integration with CodePipeline | `string` | `""` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>    label_key_case      = string<br>    label_value_case    = string<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | ecs\_cluster\_name | ECS Cluster Name | `string` | n/a | yes |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
@@ -250,9 +250,7 @@ Available targets:
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | image\_repo\_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | `string` | n/a | yes |
 | image\_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | `string` | `"latest"` | no |
-| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`. <br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
-| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation). <br>Default value: `lower`. | `string` | `null` | no |
 | local\_cache\_modes | Specifies settings that AWS CodeBuild uses to store and reuse build dependencies. Valid values: LOCAL\_SOURCE\_CACHE, LOCAL\_DOCKER\_LAYER\_CACHE, and LOCAL\_CUSTOM\_CACHE | `list(string)` | `[]` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |

--- a/context.tf
+++ b/context.tf
@@ -20,7 +20,7 @@
 
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.23.0" // requires Terraform >= 0.13.0
+  version = "0.22.1" // requires Terraform >= 0.12.26
 
   enabled             = var.enabled
   namespace           = var.namespace
@@ -54,8 +54,6 @@ variable "context" {
     regex_replace_chars = string
     label_order         = list(string)
     id_length_limit     = number
-    label_key_case      = string
-    label_value_case    = string
   })
   default = {
     enabled             = true
@@ -70,8 +68,6 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
-    label_key_case      = null
-    label_value_case    = null
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -80,16 +76,6 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
-
-  validation {
-    condition     = var.context["label_key_case"] == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-
-  validation {
-    condition     = var.context["label_value_case"] == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
 }
 
 variable "enabled" {
@@ -179,33 +165,4 @@ variable "id_length_limit" {
   EOT
 }
 
-variable "label_key_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
-    Possible values: `lower`, `title`, `upper`. 
-    Default value: `title`.
-  EOT
-
-  validation {
-    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-}
-
-variable "label_value_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of output label values (also used in `tags` and `id`).
-    Possible values: `lower`, `title`, `upper` and `none` (no transformation). 
-    Default value: `lower`.
-  EOT
-
-  validation {
-    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
-}
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.0 |
 | local | >= 1.2 |
 | null | >= 2.0 |
@@ -32,7 +32,7 @@
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `""` | no |
 | cache\_type | The type of storage that will be used for the AWS CodeBuild project cache. Valid values: NO\_CACHE, LOCAL, and S3.  Defaults to S3.  If cache\_type is S3, it will create an S3 bucket for storing codebuild cache inside | `string` | `"S3"` | no |
 | codestar\_connection\_arn | CodeStar connection ARN required for Bitbucket integration with CodePipeline | `string` | `""` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>    label_key_case      = string<br>    label_value_case    = string<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | ecs\_cluster\_name | ECS Cluster Name | `string` | n/a | yes |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
@@ -45,9 +45,7 @@
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | image\_repo\_name | ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | `string` | n/a | yes |
 | image\_tag | Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html) | `string` | `"latest"` | no |
-| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`. <br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
-| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation). <br>Default value: `lower`. | `string` | `null` | no |
 | local\_cache\_modes | Specifies settings that AWS CodeBuild uses to store and reuse build dependencies. Valid values: LOCAL\_SOURCE\_CACHE, LOCAL\_DOCKER\_LAYER\_CACHE, and LOCAL\_CUSTOM\_CACHE | `list(string)` | `[]` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -38,7 +38,6 @@
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | environment\_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build | <pre>list(object(<br>    {<br>      name  = string<br>      value = string<br>  }))</pre> | `[]` | no |
-| github\_anonymous | Github Anonymous API (if `true`, token must not be set as GITHUB\_TOKEN or `github_token`) | `bool` | `false` | no |
 | github\_oauth\_token | GitHub OAuth Token with permissions to access private repositories | `string` | `""` | no |
 | github\_webhook\_events | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/) | `list(string)` | <pre>[<br>  "push"<br>]</pre> | no |
 | github\_webhooks\_token | GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | `string` | `""` | no |

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -20,7 +20,7 @@
 
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.23.0" // requires Terraform >= 0.13.0
+  version = "0.22.1" // requires Terraform >= 0.12.26
 
   enabled             = var.enabled
   namespace           = var.namespace
@@ -54,8 +54,6 @@ variable "context" {
     regex_replace_chars = string
     label_order         = list(string)
     id_length_limit     = number
-    label_key_case      = string
-    label_value_case    = string
   })
   default = {
     enabled             = true
@@ -70,8 +68,6 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
-    label_key_case      = null
-    label_value_case    = null
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -80,16 +76,6 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
-
-  validation {
-    condition     = var.context["label_key_case"] == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-
-  validation {
-    condition     = var.context["label_value_case"] == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
 }
 
 variable "enabled" {
@@ -179,33 +165,4 @@ variable "id_length_limit" {
   EOT
 }
 
-variable "label_key_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
-    Possible values: `lower`, `title`, `upper`. 
-    Default value: `title`.
-  EOT
-
-  validation {
-    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-}
-
-variable "label_value_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of output label values (also used in `tags` and `id`).
-    Possible values: `lower`, `title`, `upper` and `none` (no transformation). 
-    Default value: `lower`.
-  EOT
-
-  validation {
-    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
-}
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -80,8 +80,6 @@ container_port_mappings = [
 
 github_oauth_token = "test"
 
-github_anonymous = true
-
 repo_owner = "cloudposse"
 
 repo_name = "terraform-aws-ecs-codepipeline"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -71,7 +71,6 @@ module "ecs_codepipeline" {
   source                  = "../../"
   region                  = var.region
   github_oauth_token      = var.github_oauth_token
-  github_anonymous        = var.github_anonymous
   repo_owner              = var.repo_owner
   repo_name               = var.repo_name
   branch                  = var.branch

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -126,11 +126,6 @@ variable "github_oauth_token" {
   description = "GitHub OAuth Token with permissions to access private repositories"
 }
 
-variable "github_anonymous" {
-  type        = bool
-  description = "Github Anonymous API (if `true`, token must not be set as GITHUB_TOKEN or `github_token`)"
-}
-
 variable "repo_owner" {
   type        = string
   description = "GitHub Organization or Username"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -428,7 +428,6 @@ module "github_webhooks" {
   version = "0.11.0"
 
   enabled              = module.this.enabled && var.webhook_enabled ? true : false
-  github_anonymous     = var.github_anonymous
   github_organization  = var.repo_owner
   github_repositories  = [var.repo_name]
   github_token         = var.github_webhooks_token

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "codepipeline_label" {
   source     = "cloudposse/label/null"
-  version    = "0.24.1"
+  version    = "0.22.1"
   attributes = ["codepipeline"]
 
   context = module.this.context
@@ -16,7 +16,7 @@ resource "aws_s3_bucket" "default" {
 
 module "codepipeline_assume_role_label" {
   source     = "cloudposse/label/null"
-  version    = "0.24.1"
+  version    = "0.22.1"
   attributes = ["codepipeline", "assume"]
 
   context = module.this.context
@@ -88,7 +88,7 @@ resource "aws_iam_role_policy_attachment" "s3" {
 
 module "codepipeline_s3_policy_label" {
   source     = "cloudposse/label/null"
-  version    = "0.24.1"
+  version    = "0.22.1"
   attributes = ["codepipeline", "s3"]
 
   context = module.this.context
@@ -130,7 +130,7 @@ resource "aws_iam_role_policy_attachment" "codebuild" {
 
 module "codebuild_label" {
   source     = "cloudposse/label/null"
-  version    = "0.24.1"
+  version    = "0.22.1"
   attributes = ["codebuild"]
 
   context = module.this.context
@@ -164,7 +164,7 @@ resource "aws_iam_role_policy_attachment" "codestar" {
 
 module "codestar_label" {
   source     = "cloudposse/label/null"
-  version    = "0.24.1"
+  version    = "0.22.1"
   enabled    = module.this.enabled && var.codestar_connection_arn != ""
   attributes = ["codestar"]
 

--- a/main.tf
+++ b/main.tf
@@ -208,7 +208,7 @@ data "aws_region" "default" {
 
 module "codebuild" {
   source                = "cloudposse/codebuild/aws"
-  version               = "0.31.0"
+  version               = "0.30.1"
   build_image           = var.build_image
   build_compute_type    = var.build_compute_type
   build_timeout         = var.build_timeout

--- a/main.tf
+++ b/main.tf
@@ -425,9 +425,8 @@ resource "aws_codepipeline_webhook" "webhook" {
 
 module "github_webhooks" {
   source  = "cloudposse/repository-webhooks/github"
-  version = "0.10.0"
-  #  TODO: update version after release of TF 0.14 and context.tf support
-  #  version              = "0.11.0"
+  version = "0.11.0"
+
   enabled              = module.this.enabled && var.webhook_enabled ? true : false
   github_anonymous     = var.github_anonymous
   github_organization  = var.repo_owner
@@ -438,6 +437,5 @@ module "github_webhooks" {
   webhook_content_type = "json"
   events               = var.github_webhook_events
 
-  #  TODO: uncomment after release
-  #  context = module.this.context
+  context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,12 +8,6 @@ variable "service_name" {
   description = "ECS Service Name"
 }
 
-variable "github_anonymous" {
-  type        = bool
-  description = "Github Anonymous API (if `true`, token must not be set as GITHUB_TOKEN or `github_token`)"
-  default     = false
-}
-
 variable "github_oauth_token" {
   type        = string
   description = "GitHub OAuth Token with permissions to access private repositories"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what
- Support TF 0.12 with pinned GitHub provider 3.0.0
- Temporarily revert TF 0.13 requirements

## why
- Dependent modules were broken because of GitHub provider issues. Fix them before abandoning TF 0.12 support

## references
https://github.com/cloudposse/terraform-aws-ecs-web-app/issues/63
