### PR TITLE
Exposes codebuilds 'cache_bucket_suffix_enabled' variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,34 @@ Available targets:
 | aws | >= 2.0 |
 | random | >= 2.1 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| codebuild | cloudposse/codebuild/aws | 0.31.1 |
+| codebuild_label | cloudposse/label/null | 0.24.1 |
+| codepipeline_assume_role_label | cloudposse/label/null | 0.24.1 |
+| codepipeline_label | cloudposse/label/null | 0.24.1 |
+| codepipeline_s3_policy_label | cloudposse/label/null | 0.24.1 |
+| codestar_label | cloudposse/label/null | 0.24.1 |
+| github_webhooks | cloudposse/repository-webhooks/github | 0.12.0 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/caller_identity) |
+| [aws_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/codepipeline) |
+| [aws_codepipeline_webhook](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/codepipeline_webhook) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_policy) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_role_policy_attachment) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/region) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/s3_bucket) |
+| [random_string](https://registry.terraform.io/providers/hashicorp/random/2.1/docs/resources/string) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -235,6 +263,7 @@ Available targets:
 | build\_image | Docker image for build environment, _e.g._ `aws/codebuild/docker:docker:17.09.0` | `string` | `"aws/codebuild/docker:17.09.0"` | no |
 | build\_timeout | How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed | `number` | `60` | no |
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `""` | no |
+| cache\_bucket\_suffix\_enabled | The cache bucket generates a random 13 character string to generate a unique bucket name. If set to false it uses terraform-null-label's id value. It only works when cache\_type is 'S3' | `bool` | `true` | no |
 | cache\_type | The type of storage that will be used for the AWS CodeBuild project cache. Valid values: NO\_CACHE, LOCAL, and S3.  Defaults to S3.  If cache\_type is S3, it will create an S3 bucket for storing codebuild cache inside | `string` | `"S3"` | no |
 | codestar\_connection\_arn | CodeStar connection ARN required for Bitbucket integration with CodePipeline | `string` | `""` | no |
 | context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
@@ -287,7 +316,6 @@ Available targets:
 | codepipeline\_id | CodePipeline ID |
 | webhook\_id | The CodePipeline webhook's ID |
 | webhook\_url | The CodePipeline webhook's URL. POST events to this endpoint to trigger the target |
-
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,6 +17,34 @@
 | aws | >= 2.0 |
 | random | >= 2.1 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| codebuild | cloudposse/codebuild/aws | 0.31.1 |
+| codebuild_label | cloudposse/label/null | 0.24.1 |
+| codepipeline_assume_role_label | cloudposse/label/null | 0.24.1 |
+| codepipeline_label | cloudposse/label/null | 0.24.1 |
+| codepipeline_s3_policy_label | cloudposse/label/null | 0.24.1 |
+| codestar_label | cloudposse/label/null | 0.24.1 |
+| github_webhooks | cloudposse/repository-webhooks/github | 0.12.0 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/caller_identity) |
+| [aws_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/codepipeline) |
+| [aws_codepipeline_webhook](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/codepipeline_webhook) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_policy) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/iam_role_policy_attachment) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/region) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/s3_bucket) |
+| [random_string](https://registry.terraform.io/providers/hashicorp/random/2.1/docs/resources/string) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -30,6 +58,7 @@
 | build\_image | Docker image for build environment, _e.g._ `aws/codebuild/docker:docker:17.09.0` | `string` | `"aws/codebuild/docker:17.09.0"` | no |
 | build\_timeout | How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed | `number` | `60` | no |
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `""` | no |
+| cache\_bucket\_suffix\_enabled | The cache bucket generates a random 13 character string to generate a unique bucket name. If set to false it uses terraform-null-label's id value. It only works when cache\_type is 'S3' | `bool` | `true` | no |
 | cache\_type | The type of storage that will be used for the AWS CodeBuild project cache. Valid values: NO\_CACHE, LOCAL, and S3.  Defaults to S3.  If cache\_type is S3, it will create an S3 bucket for storing codebuild cache inside | `string` | `"S3"` | no |
 | codestar\_connection\_arn | CodeStar connection ARN required for Bitbucket integration with CodePipeline | `string` | `""` | no |
 | context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
@@ -82,5 +111,4 @@
 | codepipeline\_id | CodePipeline ID |
 | webhook\_id | The CodePipeline webhook's ID |
 | webhook\_url | The CodePipeline webhook's URL. POST events to this endpoint to trigger the target |
-
 <!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -207,24 +207,25 @@ data "aws_region" "default" {
 }
 
 module "codebuild" {
-  source                = "cloudposse/codebuild/aws"
-  version               = "0.31.1"
-  build_image           = var.build_image
-  build_compute_type    = var.build_compute_type
-  build_timeout         = var.build_timeout
-  buildspec             = var.buildspec
-  delimiter             = module.this.delimiter
-  attributes            = ["build"]
-  privileged_mode       = var.privileged_mode
-  aws_region            = var.region != "" ? var.region : data.aws_region.default.name
-  aws_account_id        = var.aws_account_id != "" ? var.aws_account_id : data.aws_caller_identity.default.account_id
-  image_repo_name       = var.image_repo_name
-  image_tag             = var.image_tag
-  github_token          = var.github_oauth_token
-  environment_variables = var.environment_variables
-  badge_enabled         = var.badge_enabled
-  cache_type            = var.cache_type
-  local_cache_modes     = var.local_cache_modes
+  source                      = "cloudposse/codebuild/aws"
+  version                     = "0.31.1"
+  build_image                 = var.build_image
+  build_compute_type          = var.build_compute_type
+  build_timeout               = var.build_timeout
+  buildspec                   = var.buildspec
+  delimiter                   = module.this.delimiter
+  attributes                  = ["build"]
+  privileged_mode             = var.privileged_mode
+  aws_region                  = var.region != "" ? var.region : data.aws_region.default.name
+  aws_account_id              = var.aws_account_id != "" ? var.aws_account_id : data.aws_caller_identity.default.account_id
+  image_repo_name             = var.image_repo_name
+  image_tag                   = var.image_tag
+  github_token                = var.github_oauth_token
+  environment_variables       = var.environment_variables
+  badge_enabled               = var.badge_enabled
+  cache_type                  = var.cache_type
+  cache_bucket_suffix_enabled = var.cache_bucket_suffix_enabled
+  local_cache_modes           = var.local_cache_modes
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -166,6 +166,12 @@ variable "cache_type" {
   description = "The type of storage that will be used for the AWS CodeBuild project cache. Valid values: NO_CACHE, LOCAL, and S3.  Defaults to S3.  If cache_type is S3, it will create an S3 bucket for storing codebuild cache inside"
 }
 
+variable "cache_bucket_suffix_enabled" {
+  type        = bool
+  default     = true
+  description = "The cache bucket generates a random 13 character string to generate a unique bucket name. If set to false it uses terraform-null-label's id value. It only works when cache_type is 'S3'"
+}
+
 variable "local_cache_modes" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
## what
* Exposes the code build variable `var.cache_bucket_suffix_enabled`

## why
* Allowing me to set to `false` prevents the random string generation to the S3 bucket suffix. This resolves an error I am getting:
```
Error: cache location is required when cache type is "S3"

  on .terraform/modules/test_build/main.tf line 206, in resource "aws_codebuild_project" "default":
 206: resource "aws_codebuild_project" "default" {
```

## references
* This seems to be related: https://github.com/hashicorp/terraform-provider-aws/issues/10195

