### PR TITLE
feat: add support deployment of static assets to CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
-| codebuild | cloudposse/codebuild/aws | 0.32.0 |
+| codebuild | cloudposse/codebuild/aws | 0.35.0 |
 | codebuild_label | cloudposse/label/null | 0.24.1 |
 | codepipeline_assume_role_label | cloudposse/label/null | 0.24.1 |
 | codepipeline_label | cloudposse/label/null | 0.24.1 |
@@ -291,6 +291,9 @@ Available targets:
 | repo\_name | GitHub repository name of the application to be built and deployed to ECS | `string` | n/a | yes |
 | repo\_owner | GitHub Organization or Username | `string` | n/a | yes |
 | s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
+| secondary\_artifact\_bucket\_id | Optional bucket for secondary artifact deployment. If specified, the buildspec must include a secondary artifacts section which controls the artifacts deployed to the bucket [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `null` | no |
+| secondary\_artifact\_encryption\_enabled | If set to true, enable encryption on the secondary artifact bucket | `bool` | `false` | no |
+| secondary\_artifact\_identifier | Identifier for optional secondary artifact deployment. If specified, the identifier must appear in the buildspec as the name of the section which controls the artifacts deployed to the secondary artifact bucket [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `null` | no |
 | service\_name | ECS Service Name | `string` | n/a | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,7 +21,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| codebuild | cloudposse/codebuild/aws | 0.32.0 |
+| codebuild | cloudposse/codebuild/aws | 0.35.0 |
 | codebuild_label | cloudposse/label/null | 0.24.1 |
 | codepipeline_assume_role_label | cloudposse/label/null | 0.24.1 |
 | codepipeline_label | cloudposse/label/null | 0.24.1 |
@@ -86,6 +86,9 @@
 | repo\_name | GitHub repository name of the application to be built and deployed to ECS | `string` | n/a | yes |
 | repo\_owner | GitHub Organization or Username | `string` | n/a | yes |
 | s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
+| secondary\_artifact\_bucket\_id | Optional bucket for secondary artifact deployment. If specified, the buildspec must include a secondary artifacts section which controls the artifacts deployed to the bucket [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `null` | no |
+| secondary\_artifact\_encryption\_enabled | If set to true, enable encryption on the secondary artifact bucket | `bool` | `false` | no |
+| secondary\_artifact\_identifier | Identifier for optional secondary artifact deployment. If specified, the identifier must appear in the buildspec as the name of the section which controls the artifacts deployed to the secondary artifact bucket [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `null` | no |
 | service\_name | ECS Service Name | `string` | n/a | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -207,25 +207,27 @@ data "aws_region" "default" {
 }
 
 module "codebuild" {
-  source                      = "cloudposse/codebuild/aws"
-  version                     = "0.32.0"
-  build_image                 = var.build_image
-  build_compute_type          = var.build_compute_type
-  build_timeout               = var.build_timeout
-  buildspec                   = var.buildspec
-  delimiter                   = module.this.delimiter
-  attributes                  = ["build"]
-  privileged_mode             = var.privileged_mode
-  aws_region                  = var.region != "" ? var.region : data.aws_region.default.name
-  aws_account_id              = var.aws_account_id != "" ? var.aws_account_id : data.aws_caller_identity.default.account_id
-  image_repo_name             = var.image_repo_name
-  image_tag                   = var.image_tag
-  github_token                = var.github_oauth_token
-  environment_variables       = var.environment_variables
-  badge_enabled               = var.badge_enabled
-  cache_type                  = var.cache_type
-  cache_bucket_suffix_enabled = var.cache_bucket_suffix_enabled
-  local_cache_modes           = var.local_cache_modes
+  source                                = "cloudposse/codebuild/aws"
+  version                               = "0.35.0"
+  build_image                           = var.build_image
+  build_compute_type                    = var.build_compute_type
+  build_timeout                         = var.build_timeout
+  buildspec                             = var.buildspec
+  delimiter                             = module.this.delimiter
+  attributes                            = ["build"]
+  privileged_mode                       = var.privileged_mode
+  aws_region                            = var.region != "" ? var.region : data.aws_region.default.name
+  aws_account_id                        = var.aws_account_id != "" ? var.aws_account_id : data.aws_caller_identity.default.account_id
+  image_repo_name                       = var.image_repo_name
+  image_tag                             = var.image_tag
+  github_token                          = var.github_oauth_token
+  environment_variables                 = var.environment_variables
+  badge_enabled                         = var.badge_enabled
+  cache_type                            = var.cache_type
+  local_cache_modes                     = var.local_cache_modes
+  secondary_artifact_location           = var.secondary_artifact_bucket_id
+  secondary_artifact_identifier         = var.secondary_artifact_identifier
+  secondary_artifact_encryption_enabled = var.secondary_artifact_encryption_enabled
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,25 @@ variable "buildspec" {
   description = "Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html)"
 }
 
+variable "secondary_artifact_bucket_id" {
+  type        = string
+  default     = null
+  description = "Optional bucket for secondary artifact deployment. If specified, the buildspec must include a secondary artifacts section which controls the artifacts deployed to the bucket [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html)"
+}
+
+variable "secondary_artifact_encryption_enabled" {
+  type        = bool
+  default     = false
+  description = "If set to true, enable encryption on the secondary artifact bucket"
+}
+
+variable "secondary_artifact_identifier" {
+  type        = string
+  default     = null
+  description = "Identifier for optional secondary artifact deployment. If specified, the identifier must appear in the buildspec as the name of the section which controls the artifacts deployed to the secondary artifact bucket [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html)"
+}
+
+
 # https://www.terraform.io/docs/configuration/variables.html
 # It is recommended you avoid using boolean values and use explicit strings
 variable "poll_source_changes" {


### PR DESCRIPTION
## what
* Update the [terraform-aws-codebuild](https://github.com/cloudposse/terraform-aws-codebuild) dependency to pick up the secondary artifact changes
* Expose the secondary artifact configuration settings as variables

## why
* The intent is to wire the secondary artifact configuration up through the [terraform-aws-ecs-web-app](https://github.com/cloudposse/terraform-aws-ecs-web-app) module to allow for a lightweight static asset deployment through an S3 CDN that is integrated in one build

## references
* closes #72
