### PR TITLE
Add random attribute to avoid codepipeline bucket name collisions

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ecs-codepipeline&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ecs-codepipeline&utm_content=website
@@ -543,3 +543,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-ecs-codepipeline
   [share_email]: mailto:?subject=terraform-aws-ecs-codepipeline&body=https://github.com/cloudposse/terraform-aws-ecs-codepipeline
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-ecs-codepipeline?pixel&cs=github&cm=readme&an=terraform-aws-ecs-codepipeline
+<!-- markdownlint-restore -->

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -2,8 +2,10 @@ package test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 )
@@ -11,6 +13,8 @@ import (
 // Test the Terraform module in examples/complete using Terratest.
 func TestExamplesComplete(t *testing.T) {
 	t.Parallel()
+	randID := strings.ToLower(random.UniqueId())
+	attributes := []string{randID}
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
@@ -18,6 +22,9 @@ func TestExamplesComplete(t *testing.T) {
 		Upgrade:      true,
 		// Variables to pass to our Terraform code using -var-file options
 		VarFiles: []string{"fixtures.us-east-2.tfvars"},
+		Vars: map[string]interface{}{
+			"attributes": attributes,
+		},
 	}
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created
@@ -68,22 +75,22 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	ecsExecRolePolicyName := terraform.Output(t, terraformOptions, "ecs_exec_role_policy_name")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-ecs-codepipeline-exec", ecsExecRolePolicyName)
+	assert.Equal(t, "eg-test-ecs-codepipeline-"+attributes[0]+"-exec", ecsExecRolePolicyName)
 
 	// Run `terraform output` to get the value of an output variable
 	serviceName := terraform.Output(t, terraformOptions, "service_name")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-ecs-codepipeline", serviceName)
+	assert.Equal(t, "eg-test-ecs-codepipeline-"+attributes[0], serviceName)
 
 	// Run `terraform output` to get the value of an output variable
 	taskDefinitionFamily := terraform.Output(t, terraformOptions, "task_definition_family")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-ecs-codepipeline", taskDefinitionFamily)
+	assert.Equal(t, "eg-test-ecs-codepipeline-"+attributes[0], taskDefinitionFamily)
 
 	// Run `terraform output` to get the value of an output variable
 	taskExecRoleName := terraform.Output(t, terraformOptions, "task_exec_role_name")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-ecs-codepipeline-exec", taskExecRoleName)
+	assert.Equal(t, "eg-test-ecs-codepipeline-"+attributes[0]+"-exec", taskExecRoleName)
 
 	// Run `terraform output` to get the value of an output variable
 	taskExecRoleArn := terraform.Output(t, terraformOptions, "task_exec_role_arn")
@@ -93,7 +100,7 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	taskRoleName := terraform.Output(t, terraformOptions, "task_role_name")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-ecs-codepipeline-task", taskRoleName)
+	assert.Equal(t, "eg-test-ecs-codepipeline-"+attributes[0]+"-task", taskRoleName)
 
 	// Run `terraform output` to get the value of an output variable
 	taskRoleArn := terraform.Output(t, terraformOptions, "task_role_arn")
@@ -103,7 +110,7 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	codebuildProjectName := terraform.Output(t, terraformOptions, "codebuild_project_name")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-ecs-codepipeline-build", codebuildProjectName)
+	assert.Equal(t, "eg-test-ecs-codepipeline-"+attributes[0]+"-build", codebuildProjectName)
 
 	// Run `terraform output` to get the value of an output variable
 	codebuildCacheS3BucketName := terraform.Output(t, terraformOptions, "codebuild_cache_bucket_name")
@@ -113,5 +120,5 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	codepipelineId := terraform.Output(t, terraformOptions, "codepipeline_id")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-ecs-codepipeline-codepipeline", codepipelineId)
+	assert.Equal(t, "eg-test-ecs-codepipeline-codepipeline-"+attributes[0]+"-codepipeline", codepipelineId)
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -95,7 +95,7 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	taskExecRoleArn := terraform.Output(t, terraformOptions, "task_exec_role_arn")
 	// Verify we're getting back the outputs we expect
-	assert.Contains(t, taskExecRoleArn, "role/eg-test-ecs-codepipeline-exec")
+	assert.Contains(t, taskExecRoleArn, "role/eg-test-ecs-codepipeline-"+attributes[0]+"-exec")
 
 	// Run `terraform output` to get the value of an output variable
 	taskRoleName := terraform.Output(t, terraformOptions, "task_role_name")
@@ -105,7 +105,7 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	taskRoleArn := terraform.Output(t, terraformOptions, "task_role_arn")
 	// Verify we're getting back the outputs we expect
-	assert.Contains(t, taskRoleArn, "role/eg-test-ecs-codepipeline-task")
+	assert.Contains(t, taskRoleArn, "role/eg-test-ecs-codepipeline-"+attributes[0]+"-task")
 
 	// Run `terraform output` to get the value of an output variable
 	codebuildProjectName := terraform.Output(t, terraformOptions, "codebuild_project_name")
@@ -115,10 +115,10 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	codebuildCacheS3BucketName := terraform.Output(t, terraformOptions, "codebuild_cache_bucket_name")
 	// Verify we're getting back the outputs we expect
-	assert.Contains(t, codebuildCacheS3BucketName, "eg-test-ecs-codepipeline-build")
+	assert.Contains(t, codebuildCacheS3BucketName, "eg-test-ecs-codepipeline-"+attributes[0]+"-build")
 
 	// Run `terraform output` to get the value of an output variable
 	codepipelineId := terraform.Output(t, terraformOptions, "codepipeline_id")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-ecs-codepipeline-codepipeline-"+attributes[0]+"-codepipeline", codepipelineId)
+	assert.Equal(t, "eg-test-ecs-codepipeline-"+attributes[0]+"-codepipeline", codepipelineId)
 }


### PR DESCRIPTION
## what
* Adds a random string to the codepipeline module's attributes to provide a unique name for the codepipeline bucket

## why
* Automated tests sometimes fail due to bucket naming collisions (presumably when a previous test run failed and was not properly cleaned up) 

## references
* None

