### PR TITLE
Remove github_token from codebuild

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -225,7 +225,6 @@ module "codebuild" {
   aws_account_id                        = var.aws_account_id != "" ? var.aws_account_id : data.aws_caller_identity.default.account_id
   image_repo_name                       = var.image_repo_name
   image_tag                             = var.image_tag
-  github_token                          = var.github_oauth_token
   environment_variables                 = var.environment_variables
   badge_enabled                         = var.badge_enabled
   cache_type                            = var.cache_type


### PR DESCRIPTION
## what

Remove `github_token` from codebuild module

## why
- `github_oauth_token` causing conflict between `codepipeline` and `codebuild` where
    -  In `codepipeline`, its used as a REAL github token value
    -  In `codebuild`, its used as parameter store name
- `codebuild` module is not creating the parameter store resources, hence causing err during codebuild stage
    ```
    Phase context status code: Decrypted Variables Error Message: parameter does not exist: YOUR_GITHUB_TOKEN
    ```
- If `github_token` is needed, can manually put in using `environment_variables` variable

## references

- Codebuild default variable for github token type: https://github.com/cloudposse/terraform-aws-codebuild/blob/dac7df9798eb4e7211e45c182f1b5a46c5218ae4/variables.tf#L103-L107
- Can manually pass via `environment_variables` variable
